### PR TITLE
🐛 Fix auto-detection for GitHub releases

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,7 @@
 # Smart PyPI Publishing Workflow
 #
-# This workflow automatically detects version patterns and routes packages appropriately:
+# This workflow automatically detects version patterns and routes packages appropriately
+# for BOTH manual runs and GitHub releases:
 # 
 # PEP 440 Version Examples:
 #   ALPHA/DEV → TestPyPI (internal testing):
@@ -57,12 +58,7 @@ jobs:
         echo "Detected version: $VERSION"
 
         # Determine target environment
-        if [[ "${{ github.event_name }}" == "release" ]]; then
-          # For GitHub releases, use pypi (production)
-          TARGET_ENV="pypi"
-          IS_PRERELEASE="false"
-          echo "GitHub release detected - targeting PyPI"
-        elif [[ "${{ github.event.inputs.environment }}" == "pypi" ]]; then
+        if [[ "${{ github.event.inputs.environment }}" == "pypi" ]]; then
           # Force PyPI
           TARGET_ENV="pypi"
           IS_PRERELEASE="false"
@@ -73,7 +69,7 @@ jobs:
           IS_PRERELEASE="true"
           echo "Forced TestPyPI target"
         else
-          # Auto-detect based on version (PEP 440 compliant)
+          # Auto-detect based on version (PEP 440 compliant) - works for both releases and manual runs
           if [[ "$VERSION" =~ (a[0-9]+|alpha[0-9]+|\.dev[0-9]*) ]]; then
             TARGET_ENV="testpypi"
             IS_PRERELEASE="true"


### PR DESCRIPTION
**Issue:** Alpha versions created as GitHub releases were incorrectly routed to PyPI instead of TestPyPI **Root Cause:** GitHub release detection bypassed version pattern matching **Fix:** Remove GitHub release special case, use version-based detection for ALL triggers

**Changes:**
- Always use version pattern detection (a1→TestPyPI, b1→PyPI, stable→PyPI)
- Works correctly for both manual workflow runs AND GitHub releases
- Alpha releases now properly go to TestPyPI regardless of trigger type
- Updated documentation to clarify this applies to all trigger types

**Testing:**
- 0.2.0a1 GitHub release → TestPyPI ✅
- 0.3.0b1 GitHub release → PyPI ✅
- 0.3.0 GitHub release → PyPI ✅
- Manual runs still work with override options