### PR TITLE
fix: Limit auto-release to PR merges only and remove duplicate checks

### DIFF
--- a/.github/workflows/auto-release-alpha.yml
+++ b/.github/workflows/auto-release-alpha.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "release/alpha"
+    # Only trigger on PR merges, not direct commits or auto-release commits
+    # This prevents loops and ensures releases only happen after proper PR review
   workflow_dispatch:
     inputs:
       force_version:
@@ -25,14 +27,18 @@ jobs:
     runs-on: ubuntu-latest
     environment: testpypi
     
-    # Skip only explicit [skip-release] commits 
-    # Note: We don't skip auto-release commits here because the workflow has safeguards
-    # to detect recent releases and prevent actual loops in the version increment step
+    # Only trigger auto-release for PR merges, not direct commits or auto-release loops
+    # This ensures releases only happen after proper PR review and prevents infinite loops
     if: |
       github.event_name == 'workflow_dispatch' || 
       (github.event_name == 'push' && 
+       !contains(github.ref, 'refs/pull/') &&
        !contains(github.event.head_commit.message, '[skip-release]') &&
-       !contains(github.ref, 'refs/pull/'))
+       !(contains(github.event.head_commit.message, '🚀 Auto-release: Bump to v') && 
+         github.event.head_commit.author.email == 'action@github.com') &&
+       (contains(github.event.head_commit.message, 'Merge pull request #') ||
+        contains(github.event.head_commit.message, '(#') ||
+        contains(github.event.head_commit.message, 'Merge branch')))
     
     steps:
       - name: "📥 Checkout repository"
@@ -101,9 +107,8 @@ jobs:
           echo "should_skip=false" >> $GITHUB_OUTPUT
           echo "✅ No recent alpha releases detected. Proceeding with release."
 
-      - name: "🧪 Run Tests"
-        run: |
-          python -m pytest tests/ -v --cov=src/ --cov-report=term-missing --cov-fail-under=80
+      # Skip quality checks - they should have already passed during PR review
+      # This workflow focuses solely on release creation after PR approval
 
       - name: "📝 Auto-increment Alpha Version"
         id: version


### PR DESCRIPTION
Changes made to align with proper PR workflow:

✅ Auto-release now only triggers on PR merges, not direct commits ✅ Prevents auto-release loops by detecting merge patterns ✅ Removed duplicate quality checks (already run during PR review) ✅ Focuses workflow on release creation after proper approval

This ensures:
- Quality checks run during PR (CI pipeline)
- Auto-release only runs after PR approval & merge
- No loops from auto-release commits
- Clean separation of concerns