### PR TITLE
Release/beta

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -213,16 +213,17 @@ Retrieves MQTT credentials for a specific device.
 
 ### Vis Nav Robot Vacuum Methods
 
-#### `get_clean_maps(serial_number: str, include_dust_map: bool = True)`
+#### `get_clean_maps(serial_number: str, *, api_version: int, include_dust_map: bool = True)`
 ```python
 def get_clean_maps(
-    self, serial_number: str, include_dust_map: bool = True
+    self, serial_number: str, *, api_version: int, include_dust_map: bool = True
 ) -> list[CleanRecord]
 ```
 Retrieves recent cleaning run history for a Vis Nav robot vacuum.
 
 **Parameters:**
 - `serial_number` (str): Device serial number
+- `api_version` (int): API version to use — `1` for Dyson 360 Vis Nav (H8T / product type `276B`), `2` for Dyson 360 Spot+Clean and newer (VS6 / RB05 / product type `804A`)
 - `include_dust_map` (bool): When True (default), fetches the aggregated dust-density map blob for each run
 
 **Returns:** List of `CleanRecord` objects, newest first
@@ -232,14 +233,15 @@ Retrieves recent cleaning run history for a Vis Nav robot vacuum.
 - `DysonAPIError`: API request failed
 - `DysonConnectionError`: Network/connection issues
 
-#### `get_persistent_map_metadata(serial_number: str)`
+#### `get_persistent_map_metadata(serial_number: str, *, api_version: int)`
 ```python
-def get_persistent_map_metadata(self, serial_number: str) -> list[PersistentMapMeta]
+def get_persistent_map_metadata(self, serial_number: str, *, api_version: int) -> list[PersistentMapMeta]
 ```
 Retrieves the list of saved maps (zone names, IDs, and areas) for a Vis Nav.
 
 **Parameters:**
 - `serial_number` (str): Device serial number
+- `api_version` (int): API version to use — `1` for Vis Nav (H8T), `2` for Spot+Clean and newer
 
 **Returns:** List of `PersistentMapMeta` objects — one per stored map
 
@@ -248,15 +250,16 @@ Retrieves the list of saved maps (zone names, IDs, and areas) for a Vis Nav.
 - `DysonAPIError`: API request failed
 - `DysonConnectionError`: Network/connection issues
 
-#### `get_persistent_map(serial_number: str, map_id: str)`
+#### `get_persistent_map(serial_number: str, map_id: str, *, api_version: int)`
 ```python
-def get_persistent_map(self, serial_number: str, map_id: str) -> PersistentMap
+def get_persistent_map(self, serial_number: str, map_id: str, *, api_version: int) -> PersistentMap
 ```
 Retrieves the full map record for a single persistent map, including the floor-plan PNG.
 
 **Parameters:**
 - `serial_number` (str): Device serial number
 - `map_id` (str): Persistent map ID (from `get_persistent_map_metadata`)
+- `api_version` (int): API version to use — `1` for Vis Nav (H8T), `2` for Spot+Clean and newer
 
 **Returns:** `PersistentMap` with presentation image, display orientation, world offset, and zone definitions
 
@@ -693,23 +696,23 @@ Async version of get_device_credentials method.
 
 ### Vis Nav Robot Vacuum Methods
 
-#### `get_clean_maps(serial_number: str, include_dust_map: bool = True)`
+#### `get_clean_maps(serial_number: str, *, api_version: int, include_dust_map: bool = True)`
 ```python
 async def get_clean_maps(
-    self, serial_number: str, include_dust_map: bool = True
+    self, serial_number: str, *, api_version: int, include_dust_map: bool = True
 ) -> list[CleanRecord]
 ```
 Async version of `get_clean_maps`. See sync client for full parameter/return documentation.
 
-#### `get_persistent_map_metadata(serial_number: str)`
+#### `get_persistent_map_metadata(serial_number: str, *, api_version: int)`
 ```python
-async def get_persistent_map_metadata(self, serial_number: str) -> list[PersistentMapMeta]
+async def get_persistent_map_metadata(self, serial_number: str, *, api_version: int) -> list[PersistentMapMeta]
 ```
 Async version of `get_persistent_map_metadata`.
 
-#### `get_persistent_map(serial_number: str, map_id: str)`
+#### `get_persistent_map(serial_number: str, map_id: str, *, api_version: int)`
 ```python
-async def get_persistent_map(self, serial_number: str, map_id: str) -> PersistentMap
+async def get_persistent_map(self, serial_number: str, map_id: str, *, api_version: int) -> PersistentMap
 ```
 Async version of `get_persistent_map`.
 
@@ -778,10 +781,10 @@ async with AsyncDysonClient("user@example.com", "password") as client:
 | Get Devices | `get_devices()` | `await get_devices()` | Returns device list |
 | Get Device | `get_device_by_serial()` | `await get_device_by_serial()` | Find by serial |
 | Get Credentials | `get_device_credentials()` | `await get_device_credentials()` | MQTT credentials |
-| **Clean Maps** | `get_clean_maps()` | `await get_clean_maps()` | Vis Nav history (v2) |
-| **Clean Map Data** | `get_clean_map_data()` | `await get_clean_map_data()` | Detailed session data |
-| **Map Metadata** | `get_persistent_map_metadata()` | `await get_persistent_map_metadata()` | Zone names/IDs (v2) |
-| **Full Map** | `get_persistent_map()` | `await get_persistent_map()` | Floor-plan PNG (v2) |
+| **Clean Maps** | `get_clean_maps()` | `await get_clean_maps()` | Requires `api_version=1` (Vis Nav) or `api_version=2` (Spot+Clean) |
+| **Clean Map Data** | `get_clean_map_data()` | `await get_clean_map_data()` | Detailed session data (v2 only) |
+| **Map Metadata** | `get_persistent_map_metadata()` | `await get_persistent_map_metadata()` | Requires `api_version=1` or `api_version=2` |
+| **Full Map** | `get_persistent_map()` | `await get_persistent_map()` | Requires `api_version=1` or `api_version=2` |
 | **Update Map** | `update_persistent_map()` | `await update_persistent_map()` | Rename persistent map |
 | **Delete Map** | `delete_persistent_map()` | `await delete_persistent_map()` | Remove persistent map |
 | **Update Metadata** | `update_map_metadata()` | `await update_map_metadata()` | Update map metadata |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libdyson-rest"
-version = "0.15.0"
+version = "0.16.0b1"
 description = "Python library for interacting with Dyson devices through their official REST API"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libdyson-rest"
-version = "0.16.0b1"
+version = "0.16.0b2"
 description = "Python library for interacting with Dyson devices through their official REST API"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libdyson-rest"
-version = "0.16.0b2"
+version = "0.16.0b3"
 description = "Python library for interacting with Dyson devices through their official REST API"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libdyson-rest"
-version = "0.16.0b3"
+version = "0.16.0"
 description = "Python library for interacting with Dyson devices through their official REST API"
 readme = "README.md"
 license = "MIT"

--- a/src/libdyson_rest/__init__.py
+++ b/src/libdyson_rest/__init__.py
@@ -48,7 +48,7 @@ Basic Usage (Asynchronous):
                 print(f"Device: {device.name} ({device.serial_number})")
 """
 
-__version__ = "0.16.0b1"
+__version__ = "0.16.0b2"
 __author__ = "Christopher Gray"
 __email__ = "79777799+cmgrayb@users.noreply.github.com"
 

--- a/src/libdyson_rest/__init__.py
+++ b/src/libdyson_rest/__init__.py
@@ -48,7 +48,7 @@ Basic Usage (Asynchronous):
                 print(f"Device: {device.name} ({device.serial_number})")
 """
 
-__version__ = "0.16.0b2"
+__version__ = "0.16.0b3"
 __author__ = "Christopher Gray"
 __email__ = "79777799+cmgrayb@users.noreply.github.com"
 
@@ -64,6 +64,7 @@ from .exceptions import (
     DysonAuthError,
     DysonConnectionError,
     DysonDeviceError,
+    DysonMapError,
     DysonValidationError,
 )
 from .models import (
@@ -97,6 +98,7 @@ from .models import (
     ZoneMeta,
     ZonePrediction,
     decode_dust_map,
+    find_current_map,
 )
 
 __all__ = [
@@ -108,6 +110,7 @@ __all__ = [
     "DysonAuthError",
     "DysonConnectionError",
     "DysonDeviceError",
+    "DysonMapError",
     "DysonValidationError",
     # Core device models
     "Device",
@@ -137,6 +140,7 @@ __all__ = [
     "ZoneMeta",
     "ZonePrediction",
     "decode_dust_map",
+    "find_current_map",
     # EC air purifier models
     "DailyAirQualityData",
     "OutdoorAirQualityData",

--- a/src/libdyson_rest/__init__.py
+++ b/src/libdyson_rest/__init__.py
@@ -48,7 +48,7 @@ Basic Usage (Asynchronous):
                 print(f"Device: {device.name} ({device.serial_number})")
 """
 
-__version__ = "0.15.0"
+__version__ = "0.16.0b1"
 __author__ = "Christopher Gray"
 __email__ = "79777799+cmgrayb@users.noreply.github.com"
 

--- a/src/libdyson_rest/__init__.py
+++ b/src/libdyson_rest/__init__.py
@@ -48,7 +48,7 @@ Basic Usage (Asynchronous):
                 print(f"Device: {device.name} ({device.serial_number})")
 """
 
-__version__ = "0.16.0b3"
+__version__ = "0.16.0"
 __author__ = "Christopher Gray"
 __email__ = "79777799+cmgrayb@users.noreply.github.com"
 

--- a/src/libdyson_rest/async_client.py
+++ b/src/libdyson_rest/async_client.py
@@ -1089,12 +1089,14 @@ class AsyncDysonClient:
     # ------------------------------------------------------------------
 
     async def get_clean_maps(
-        self, serial_number: str, include_dust_map: bool = True
+        self, serial_number: str, *, api_version: int, include_dust_map: bool = True
     ) -> list[CleanRecord]:
         """Get recent cleaning runs for a Vis Nav robot vacuum.
 
         Args:
             serial_number: Device serial number.
+            api_version: API version to use (1 for Vis Nav / H8T devices,
+                2 for Spot+Clean / VS6/RB05 devices).
             include_dust_map: When True (default), requests the aggregated
                 dust-density map blob for each run (``dustMap=total``).
 
@@ -1109,7 +1111,10 @@ class AsyncDysonClient:
         if not self._auth_token:
             raise DysonAuthError("Must authenticate before calling get_clean_maps")
 
-        url = urljoin(get_api_hostname(self.country), f"/v2/{serial_number}/clean-maps")
+        url = urljoin(
+            get_api_hostname(self.country),
+            f"/v{api_version}/{serial_number}/clean-maps",
+        )
         params: dict[str, str] = {}
         if include_dust_map:
             params["dustMap"] = "total"
@@ -1146,12 +1151,14 @@ class AsyncDysonClient:
             ) from e
 
     async def get_persistent_map_metadata(
-        self, serial_number: str
+        self, serial_number: str, *, api_version: int
     ) -> list[PersistentMapMeta]:
         """Get persistent map metadata (zone names, IDs, areas) for a Vis Nav.
 
         Args:
             serial_number: Device serial number.
+            api_version: API version to use (1 for Vis Nav / H8T devices,
+                2 for Spot+Clean / VS6/RB05 devices).
 
         Returns:
             List of PersistentMapMeta objects (one per stored map).
@@ -1168,7 +1175,7 @@ class AsyncDysonClient:
 
         url = urljoin(
             get_api_hostname(self.country),
-            f"/v2/app/{serial_number}/persistent-map-metadata",
+            f"/v{api_version}/app/{serial_number}/persistent-map-metadata",
         )
 
         try:
@@ -1203,13 +1210,15 @@ class AsyncDysonClient:
             ) from e
 
     async def get_persistent_map(
-        self, serial_number: str, map_id: str
+        self, serial_number: str, map_id: str, *, api_version: int
     ) -> PersistentMap:
         """Get the full persistent map record including the floor-plan PNG.
 
         Args:
             serial_number: Device serial number.
             map_id: Persistent map ID (from get_persistent_map_metadata).
+            api_version: API version to use (1 for Vis Nav / H8T devices,
+                2 for Spot+Clean / VS6/RB05 devices).
 
         Returns:
             PersistentMap with presentation image, orientation, offset, and zones.
@@ -1224,7 +1233,7 @@ class AsyncDysonClient:
 
         url = urljoin(
             get_api_hostname(self.country),
-            f"/v2/app/{serial_number}/persistent-maps/{map_id}",
+            f"/v{api_version}/app/{serial_number}/persistent-maps/{map_id}",
         )
 
         try:

--- a/src/libdyson_rest/client.py
+++ b/src/libdyson_rest/client.py
@@ -1072,12 +1072,14 @@ class DysonClient:
     # ------------------------------------------------------------------
 
     def get_clean_maps(
-        self, serial_number: str, include_dust_map: bool = True
+        self, serial_number: str, *, api_version: int, include_dust_map: bool = True
     ) -> list[CleanRecord]:
         """Get recent cleaning runs for a Vis Nav robot vacuum.
 
         Args:
             serial_number: Device serial number.
+            api_version: API version to use (1 for Vis Nav / H8T devices,
+                2 for Spot+Clean / VS6/RB05 devices).
             include_dust_map: When True (default), requests the aggregated
                 dust-density map blob for each run (``dustMap=total``).
 
@@ -1092,7 +1094,10 @@ class DysonClient:
         if not self._auth_token:
             raise DysonAuthError("Must authenticate before calling get_clean_maps")
 
-        url = urljoin(get_api_hostname(self.country), f"/v2/{serial_number}/clean-maps")
+        url = urljoin(
+            get_api_hostname(self.country),
+            f"/v{api_version}/{serial_number}/clean-maps",
+        )
         params: dict[str, str] = {}
         if include_dust_map:
             params["dustMap"] = "total"
@@ -1130,12 +1135,14 @@ class DysonClient:
             ) from e
 
     def get_persistent_map_metadata(
-        self, serial_number: str
+        self, serial_number: str, *, api_version: int
     ) -> list[PersistentMapMeta]:
         """Get persistent map metadata (zone names, IDs, areas) for a Vis Nav.
 
         Args:
             serial_number: Device serial number.
+            api_version: API version to use (1 for Vis Nav / H8T devices,
+                2 for Spot+Clean / VS6/RB05 devices).
 
         Returns:
             List of PersistentMapMeta objects (one per stored map).
@@ -1152,7 +1159,7 @@ class DysonClient:
 
         url = urljoin(
             get_api_hostname(self.country),
-            f"/v2/app/{serial_number}/persistent-map-metadata",
+            f"/v{api_version}/app/{serial_number}/persistent-map-metadata",
         )
 
         try:
@@ -1187,12 +1194,16 @@ class DysonClient:
                 raw=response.text,
             ) from e
 
-    def get_persistent_map(self, serial_number: str, map_id: str) -> PersistentMap:
+    def get_persistent_map(
+        self, serial_number: str, map_id: str, *, api_version: int
+    ) -> PersistentMap:
         """Get the full persistent map record including the floor-plan PNG.
 
         Args:
             serial_number: Device serial number.
             map_id: Persistent map ID (from get_persistent_map_metadata).
+            api_version: API version to use (1 for Vis Nav / H8T devices,
+                2 for Spot+Clean / VS6/RB05 devices).
 
         Returns:
             PersistentMap with presentation image, orientation, offset, and zones.
@@ -1207,7 +1218,7 @@ class DysonClient:
 
         url = urljoin(
             get_api_hostname(self.country),
-            f"/v2/app/{serial_number}/persistent-maps/{map_id}",
+            f"/v{api_version}/app/{serial_number}/persistent-maps/{map_id}",
         )
 
         try:

--- a/src/libdyson_rest/exceptions.py
+++ b/src/libdyson_rest/exceptions.py
@@ -33,3 +33,9 @@ class DysonValidationError(DysonAPIError):
     """Raised when input validation fails."""
 
     pass
+
+
+class DysonMapError(DysonAPIError):
+    """Raised when the active floor map cannot be determined."""
+
+    pass

--- a/src/libdyson_rest/models/__init__.py
+++ b/src/libdyson_rest/models/__init__.py
@@ -47,6 +47,7 @@ from .robot import (
     ZoneMeta,
     ZonePrediction,
     decode_dust_map,
+    find_current_map,
 )
 
 __all__ = [
@@ -87,6 +88,7 @@ __all__ = [
     "ZoneMeta",
     "ZonePrediction",
     "decode_dust_map",
+    "find_current_map",
     # Environment / EC purifier models
     "DailyAirQualityData",
     "OutdoorAirQualityData",

--- a/src/libdyson_rest/models/robot.py
+++ b/src/libdyson_rest/models/robot.py
@@ -654,6 +654,7 @@ class PersistentMapMeta:
     name: str | None
     zones_definition_last_updated_date: str | None
     zones: list[ZoneMeta]
+    is_current_map: bool = False
 
     @classmethod
     def from_dict(cls, data: PersistentMapMetaDict) -> PersistentMapMeta:
@@ -671,6 +672,7 @@ class PersistentMapMeta:
                 "zonesDefinitionLastUpdatedDate"
             ),
             zones=zones,
+            is_current_map=bool(raw.get("isCurrentMap", False)),
         )
 
     def zone_by_id(self, zone_id: str) -> ZoneMeta | None:

--- a/src/libdyson_rest/models/robot.py
+++ b/src/libdyson_rest/models/robot.py
@@ -645,9 +645,10 @@ class ZoneMeta:
 class PersistentMapMeta:
     """One entry from GET /v1/app/{serial}/persistent-map-metadata.
 
-    Contains map identification, zone list with human-readable names, and the
+    Contains map identification, zone list with human-readable names, the
     ``zones_definition_last_updated_date`` timestamp that must be included in
-    zone-clean MQTT payloads so the device honours the request.
+    zone-clean MQTT payloads so the device honours the request, and the
+    ``last_visited`` timestamp of the map's most recent robot activity.
     """
 
     id: str
@@ -655,6 +656,7 @@ class PersistentMapMeta:
     zones_definition_last_updated_date: str | None
     zones: list[ZoneMeta]
     is_current_map: bool = False
+    last_visited: str | None = None
 
     @classmethod
     def from_dict(cls, data: PersistentMapMetaDict) -> PersistentMapMeta:
@@ -673,6 +675,7 @@ class PersistentMapMeta:
             ),
             zones=zones,
             is_current_map=bool(raw.get("isCurrentMap", False)),
+            last_visited=raw.get("lastVisited"),
         )
 
     def zone_by_id(self, zone_id: str) -> ZoneMeta | None:

--- a/src/libdyson_rest/models/robot.py
+++ b/src/libdyson_rest/models/robot.py
@@ -22,9 +22,11 @@ import base64 as _base64
 import struct as _struct
 import zlib as _zlib
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, cast
 
+from ..exceptions import DysonMapError
 from ..types import (
     CleanFaultDict,
     CleanRecordDict,
@@ -654,7 +656,8 @@ class PersistentMapMeta:
     name: str | None
     zones_definition_last_updated_date: str | None
     zones: list[ZoneMeta]
-    is_current_map: bool = False
+    is_current_map: bool = False  # v2: explicit active-map flag
+    last_visited: str | None = None  # v1: ISO-8601 timestamp
 
     @classmethod
     def from_dict(cls, data: PersistentMapMetaDict) -> PersistentMapMeta:
@@ -673,6 +676,7 @@ class PersistentMapMeta:
             ),
             zones=zones,
             is_current_map=bool(raw.get("isCurrentMap", False)),
+            last_visited=raw.get("lastVisited") or None,
         )
 
     def zone_by_id(self, zone_id: str) -> ZoneMeta | None:
@@ -685,6 +689,51 @@ class PersistentMapMeta:
         return next(
             (z for z in self.zones if (z.name or "").lower() == name_lower), None
         )
+
+
+def find_current_map(maps: list[PersistentMapMeta]) -> PersistentMapMeta:
+    """Return the active map from a list of ``PersistentMapMeta`` objects.
+
+    Selection priority:
+
+    1. **v2 devices** — any map with ``is_current_map=True``.
+    2. **v1 devices** — map with the most recent ``last_visited`` timestamp.
+    3. **Unambiguous** — exactly one map present with no active-map signal.
+    4. **Error** — raises ``DysonMapError`` when multiple maps are present
+       and no active-map signal is available.
+
+    Raises:
+        DysonMapError: When the active map cannot be determined.
+    """
+    # Step 1: v2 explicit flag
+    for m in maps:
+        if m.is_current_map:
+            return m
+
+    # Step 2: v1 last_visited timestamp — pick the most recent
+    visited = [m for m in maps if m.last_visited]
+    if visited:
+        _epoch = datetime.min.replace(tzinfo=timezone.utc)
+
+        def _parse_dt(m: PersistentMapMeta) -> datetime:
+            try:
+                ts = (m.last_visited or "").replace("Z", "+00:00")
+                dt = datetime.fromisoformat(ts)
+                return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+            except ValueError:
+                return _epoch
+
+        return max(visited, key=_parse_dt)
+
+    # Step 3: unambiguous single map
+    if len(maps) == 1:
+        return maps[0]
+
+    # Step 4: cannot determine
+    raise DysonMapError(
+        "Cannot determine current map: no is_current_map flag and no "
+        "last_visited timestamp present"
+    )
 
 
 @dataclass

--- a/src/libdyson_rest/types.py
+++ b/src/libdyson_rest/types.py
@@ -234,6 +234,7 @@ class PersistentMapMetaDict(TypedDict):
     zonesDefinitionLastUpdatedDate: NotRequired[str]
     zones: NotRequired[list[ZoneMetaDict]]
     isCurrentMap: NotRequired[bool]
+    lastVisited: NotRequired[str]
 
 
 class PresentationMapDict(TypedDict):

--- a/src/libdyson_rest/types.py
+++ b/src/libdyson_rest/types.py
@@ -233,6 +233,7 @@ class PersistentMapMetaDict(TypedDict):
     name: NotRequired[str]
     zonesDefinitionLastUpdatedDate: NotRequired[str]
     zones: NotRequired[list[ZoneMetaDict]]
+    isCurrentMap: NotRequired[bool]
 
 
 class PresentationMapDict(TypedDict):

--- a/src/libdyson_rest/types.py
+++ b/src/libdyson_rest/types.py
@@ -233,7 +233,8 @@ class PersistentMapMetaDict(TypedDict):
     name: NotRequired[str]
     zonesDefinitionLastUpdatedDate: NotRequired[str]
     zones: NotRequired[list[ZoneMetaDict]]
-    isCurrentMap: NotRequired[bool]
+    isCurrentMap: NotRequired[bool]  # v2 devices: explicit active-map flag
+    lastVisited: NotRequired[str]  # v1 devices: ISO-8601 timestamp
 
 
 class PresentationMapDict(TypedDict):

--- a/tests/unit/test_async_coverage_gaps.py
+++ b/tests/unit/test_async_coverage_gaps.py
@@ -468,7 +468,7 @@ class TestGetCleanMapsErrorPaths:
         mock_get.side_effect = _server_error()
         client = AsyncDysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError):
-            await client.get_clean_maps(SERIAL)
+            await client.get_clean_maps(SERIAL, api_version=2)
         await client.close()
 
     @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
@@ -477,7 +477,7 @@ class TestGetCleanMapsErrorPaths:
         mock_get.return_value = _json_error(Mock())
         client = AsyncDysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError):
-            await client.get_clean_maps(SERIAL)
+            await client.get_clean_maps(SERIAL, api_version=2)
         await client.close()
 
 
@@ -488,7 +488,7 @@ class TestGetPersistentMapMetadataErrorPaths:
         mock_get.side_effect = _server_error()
         client = AsyncDysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError):
-            await client.get_persistent_map_metadata(SERIAL)
+            await client.get_persistent_map_metadata(SERIAL, api_version=2)
         await client.close()
 
     @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
@@ -497,7 +497,7 @@ class TestGetPersistentMapMetadataErrorPaths:
         mock_get.return_value = _json_error(Mock())
         client = AsyncDysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError):
-            await client.get_persistent_map_metadata(SERIAL)
+            await client.get_persistent_map_metadata(SERIAL, api_version=2)
         await client.close()
 
 
@@ -508,7 +508,7 @@ class TestGetPersistentMapErrorPaths:
         mock_get.side_effect = _server_error()
         client = AsyncDysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError):
-            await client.get_persistent_map(SERIAL, MAP_ID)
+            await client.get_persistent_map(SERIAL, MAP_ID, api_version=2)
         await client.close()
 
     @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
@@ -517,7 +517,7 @@ class TestGetPersistentMapErrorPaths:
         mock_get.return_value = _json_error(Mock())
         client = AsyncDysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError):
-            await client.get_persistent_map(SERIAL, MAP_ID)
+            await client.get_persistent_map(SERIAL, MAP_ID, api_version=2)
         await client.close()
 
 

--- a/tests/unit/test_robot_endpoints.py
+++ b/tests/unit/test_robot_endpoints.py
@@ -120,7 +120,7 @@ class TestSyncGetCleanMaps:
         mock_get.return_value = mock_response
 
         client = DysonClient(auth_token="tok")
-        records = client.get_clean_maps(SERIAL)
+        records = client.get_clean_maps(SERIAL, api_version=2)
 
         assert len(records) == 1
         assert isinstance(records[0], CleanRecord)
@@ -135,7 +135,7 @@ class TestSyncGetCleanMaps:
         mock_get.return_value = mock_response
 
         client = DysonClient(auth_token="tok")
-        client.get_clean_maps(SERIAL)
+        client.get_clean_maps(SERIAL, api_version=2)
 
         call_kwargs = mock_get.call_args.kwargs
         assert call_kwargs.get("params") == {"dustMap": "total"}
@@ -148,7 +148,7 @@ class TestSyncGetCleanMaps:
         mock_get.return_value = mock_response
 
         client = DysonClient(auth_token="tok")
-        client.get_clean_maps(SERIAL, include_dust_map=False)
+        client.get_clean_maps(SERIAL, api_version=2, include_dust_map=False)
 
         call_kwargs = mock_get.call_args.kwargs
         assert call_kwargs.get("params") == {}
@@ -156,7 +156,7 @@ class TestSyncGetCleanMaps:
     def test_raises_auth_error_when_not_authenticated(self) -> None:
         client = DysonClient()
         with pytest.raises(DysonAuthError, match="Must authenticate"):
-            client.get_clean_maps(SERIAL)
+            client.get_clean_maps(SERIAL, api_version=2)
 
     @patch("httpx.Client.get")
     def test_raises_auth_error_on_401(self, mock_get: Mock) -> None:
@@ -168,7 +168,7 @@ class TestSyncGetCleanMaps:
 
         client = DysonClient(auth_token="tok")
         with pytest.raises(DysonAuthError, match="expired"):
-            client.get_clean_maps(SERIAL)
+            client.get_clean_maps(SERIAL, api_version=2)
 
     @patch("httpx.Client.get")
     def test_raises_connection_error_on_network_failure(self, mock_get: Mock) -> None:
@@ -176,7 +176,7 @@ class TestSyncGetCleanMaps:
 
         client = DysonClient(auth_token="tok")
         with pytest.raises(DysonConnectionError):
-            client.get_clean_maps(SERIAL)
+            client.get_clean_maps(SERIAL, api_version=2)
 
     @patch("httpx.Client.get")
     def test_raises_api_error_on_non_list_response(self, mock_get: Mock) -> None:
@@ -188,7 +188,7 @@ class TestSyncGetCleanMaps:
 
         client = DysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError, match="Expected list") as exc_info:
-            client.get_clean_maps(SERIAL)
+            client.get_clean_maps(SERIAL, api_version=2)
         assert exc_info.value.raw == '{"error": "unexpected"}'
 
     @patch("httpx.Client.get")
@@ -200,7 +200,7 @@ class TestSyncGetCleanMaps:
         mock_get.return_value = mock_response
 
         client = DysonClient(auth_token="tok")
-        records = client.get_clean_maps(SERIAL)
+        records = client.get_clean_maps(SERIAL, api_version=2)
 
         assert len(records) == 1
         record = records[0]
@@ -234,7 +234,33 @@ class TestSyncGetCleanMaps:
 
         client = DysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError, match="Expected list"):
-            client.get_clean_maps(SERIAL)
+            client.get_clean_maps(SERIAL, api_version=2)
+
+    @patch("httpx.Client.get")
+    def test_v2_url_used(self, mock_get: Mock) -> None:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        client = DysonClient(auth_token="tok")
+        client.get_clean_maps(SERIAL, api_version=2)
+
+        url = mock_get.call_args.args[0]
+        assert f"/v2/{SERIAL}/clean-maps" in url
+
+    @patch("httpx.Client.get")
+    def test_v1_url_used_for_vis_nav(self, mock_get: Mock) -> None:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        client = DysonClient(auth_token="tok")
+        client.get_clean_maps(SERIAL, api_version=1)
+
+        url = mock_get.call_args.args[0]
+        assert f"/v1/{SERIAL}/clean-maps" in url
 
 
 class TestSyncGetPersistentMapMetadata:
@@ -246,7 +272,7 @@ class TestSyncGetPersistentMapMetadata:
         mock_get.return_value = mock_response
 
         client = DysonClient(auth_token="tok")
-        metas = client.get_persistent_map_metadata(SERIAL)
+        metas = client.get_persistent_map_metadata(SERIAL, api_version=2)
 
         assert len(metas) == 1
         assert isinstance(metas[0], PersistentMapMeta)
@@ -256,7 +282,7 @@ class TestSyncGetPersistentMapMetadata:
     def test_raises_auth_error_when_not_authenticated(self) -> None:
         client = DysonClient()
         with pytest.raises(DysonAuthError):
-            client.get_persistent_map_metadata(SERIAL)
+            client.get_persistent_map_metadata(SERIAL, api_version=2)
 
     @patch("httpx.Client.get")
     def test_raises_api_error_on_non_list_response(self, mock_get: Mock) -> None:
@@ -268,7 +294,7 @@ class TestSyncGetPersistentMapMetadata:
 
         client = DysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError, match="Expected list") as exc_info:
-            client.get_persistent_map_metadata(SERIAL)
+            client.get_persistent_map_metadata(SERIAL, api_version=2)
         assert exc_info.value.raw == f'{{"id": "{MAP_ID}"}}'
 
     @patch("httpx.Client.get")
@@ -279,10 +305,23 @@ class TestSyncGetPersistentMapMetadata:
         mock_get.return_value = mock_response
 
         client = DysonClient(auth_token="tok")
-        client.get_persistent_map_metadata(SERIAL)
+        client.get_persistent_map_metadata(SERIAL, api_version=2)
 
         url = mock_get.call_args.args[0]
         assert f"/v2/app/{SERIAL}/persistent-map-metadata" in url
+
+    @patch("httpx.Client.get")
+    def test_v1_url_used_for_vis_nav(self, mock_get: Mock) -> None:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        client = DysonClient(auth_token="tok")
+        client.get_persistent_map_metadata(SERIAL, api_version=1)
+
+        url = mock_get.call_args.args[0]
+        assert f"/v1/app/{SERIAL}/persistent-map-metadata" in url
 
     @patch("httpx.Client.get")
     def test_raises_connection_error_on_network_failure(self, mock_get: Mock) -> None:
@@ -290,7 +329,7 @@ class TestSyncGetPersistentMapMetadata:
 
         client = DysonClient(auth_token="tok")
         with pytest.raises(DysonConnectionError):
-            client.get_persistent_map_metadata(SERIAL)
+            client.get_persistent_map_metadata(SERIAL, api_version=2)
 
 
 class TestSyncGetPersistentMap:
@@ -302,7 +341,7 @@ class TestSyncGetPersistentMap:
         mock_get.return_value = mock_response
 
         client = DysonClient(auth_token="tok")
-        pm = client.get_persistent_map(SERIAL, MAP_ID)
+        pm = client.get_persistent_map(SERIAL, MAP_ID, api_version=2)
 
         assert isinstance(pm, PersistentMap)
         assert pm.id == MAP_ID
@@ -313,7 +352,7 @@ class TestSyncGetPersistentMap:
     def test_raises_auth_error_when_not_authenticated(self) -> None:
         client = DysonClient()
         with pytest.raises(DysonAuthError):
-            client.get_persistent_map(SERIAL, MAP_ID)
+            client.get_persistent_map(SERIAL, MAP_ID, api_version=2)
 
     @patch("httpx.Client.get")
     def test_raises_api_error_on_non_dict_response(self, mock_get: Mock) -> None:
@@ -324,7 +363,7 @@ class TestSyncGetPersistentMap:
 
         client = DysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError, match="Expected object"):
-            client.get_persistent_map(SERIAL, MAP_ID)
+            client.get_persistent_map(SERIAL, MAP_ID, api_version=2)
 
     @patch("httpx.Client.get")
     def test_correct_url_includes_map_id(self, mock_get: Mock) -> None:
@@ -334,10 +373,23 @@ class TestSyncGetPersistentMap:
         mock_get.return_value = mock_response
 
         client = DysonClient(auth_token="tok")
-        client.get_persistent_map(SERIAL, MAP_ID)
+        client.get_persistent_map(SERIAL, MAP_ID, api_version=2)
 
         url = mock_get.call_args.args[0]
         assert f"/v2/app/{SERIAL}/persistent-maps/{MAP_ID}" in url
+
+    @patch("httpx.Client.get")
+    def test_v1_url_includes_map_id(self, mock_get: Mock) -> None:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = PERSISTENT_MAP_ITEM
+        mock_get.return_value = mock_response
+
+        client = DysonClient(auth_token="tok")
+        client.get_persistent_map(SERIAL, MAP_ID, api_version=1)
+
+        url = mock_get.call_args.args[0]
+        assert f"/v1/app/{SERIAL}/persistent-maps/{MAP_ID}" in url
 
     @patch("httpx.Client.get")
     def test_raises_connection_error_on_network_failure(self, mock_get: Mock) -> None:
@@ -345,7 +397,7 @@ class TestSyncGetPersistentMap:
 
         client = DysonClient(auth_token="tok")
         with pytest.raises(DysonConnectionError):
-            client.get_persistent_map(SERIAL, MAP_ID)
+            client.get_persistent_map(SERIAL, MAP_ID, api_version=2)
 
 
 class TestSyncGetRecommendedCleans:
@@ -472,7 +524,7 @@ class TestAsyncGetCleanMaps:
         mock_get.return_value = mock_response
 
         client = AsyncDysonClient(auth_token="tok")
-        records = await client.get_clean_maps(SERIAL)
+        records = await client.get_clean_maps(SERIAL, api_version=2)
 
         assert len(records) == 1
         assert isinstance(records[0], CleanRecord)
@@ -483,7 +535,7 @@ class TestAsyncGetCleanMaps:
     async def test_raises_auth_error_when_not_authenticated(self) -> None:
         client = AsyncDysonClient()
         with pytest.raises(DysonAuthError):
-            await client.get_clean_maps(SERIAL)
+            await client.get_clean_maps(SERIAL, api_version=2)
         await client.close()
 
     @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
@@ -497,7 +549,7 @@ class TestAsyncGetCleanMaps:
 
         client = AsyncDysonClient(auth_token="tok")
         with pytest.raises(DysonAuthError, match="expired"):
-            await client.get_clean_maps(SERIAL)
+            await client.get_clean_maps(SERIAL, api_version=2)
         await client.close()
 
     @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
@@ -509,7 +561,7 @@ class TestAsyncGetCleanMaps:
 
         client = AsyncDysonClient(auth_token="tok")
         with pytest.raises(DysonConnectionError):
-            await client.get_clean_maps(SERIAL)
+            await client.get_clean_maps(SERIAL, api_version=2)
         await client.close()
 
     @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
@@ -525,7 +577,7 @@ class TestAsyncGetCleanMaps:
 
         client = AsyncDysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError, match="Expected list") as exc_info:
-            await client.get_clean_maps(SERIAL)
+            await client.get_clean_maps(SERIAL, api_version=2)
         assert exc_info.value.raw == '{"error": "oops"}'
         await client.close()
 
@@ -541,7 +593,7 @@ class TestAsyncGetCleanMaps:
         mock_get.return_value = mock_response
 
         client = AsyncDysonClient(auth_token="tok")
-        records = await client.get_clean_maps(SERIAL)
+        records = await client.get_clean_maps(SERIAL, api_version=2)
 
         assert len(records) == 1
         record = records[0]
@@ -568,7 +620,37 @@ class TestAsyncGetCleanMaps:
 
         client = AsyncDysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError, match="Expected list"):
-            await client.get_clean_maps(SERIAL)
+            await client.get_clean_maps(SERIAL, api_version=2)
+        await client.close()
+
+    @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_v2_url_used(self, mock_get: AsyncMock) -> None:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        client = AsyncDysonClient(auth_token="tok")
+        await client.get_clean_maps(SERIAL, api_version=2)
+
+        url = mock_get.call_args.args[0]
+        assert f"/v2/{SERIAL}/clean-maps" in url
+        await client.close()
+
+    @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_v1_url_used_for_vis_nav(self, mock_get: AsyncMock) -> None:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        client = AsyncDysonClient(auth_token="tok")
+        await client.get_clean_maps(SERIAL, api_version=1)
+
+        url = mock_get.call_args.args[0]
+        assert f"/v1/{SERIAL}/clean-maps" in url
         await client.close()
 
 
@@ -582,7 +664,7 @@ class TestAsyncGetPersistentMapMetadata:
         mock_get.return_value = mock_response
 
         client = AsyncDysonClient(auth_token="tok")
-        metas = await client.get_persistent_map_metadata(SERIAL)
+        metas = await client.get_persistent_map_metadata(SERIAL, api_version=2)
 
         assert len(metas) == 1
         assert isinstance(metas[0], PersistentMapMeta)
@@ -593,7 +675,7 @@ class TestAsyncGetPersistentMapMetadata:
     async def test_raises_auth_error_when_not_authenticated(self) -> None:
         client = AsyncDysonClient()
         with pytest.raises(DysonAuthError):
-            await client.get_persistent_map_metadata(SERIAL)
+            await client.get_persistent_map_metadata(SERIAL, api_version=2)
         await client.close()
 
     @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
@@ -609,8 +691,38 @@ class TestAsyncGetPersistentMapMetadata:
 
         client = AsyncDysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError, match="Expected list") as exc_info:
-            await client.get_persistent_map_metadata(SERIAL)
+            await client.get_persistent_map_metadata(SERIAL, api_version=2)
         assert exc_info.value.raw == f'{{"id": "{MAP_ID}"}}'
+        await client.close()
+
+    @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_v2_url_used(self, mock_get: AsyncMock) -> None:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        client = AsyncDysonClient(auth_token="tok")
+        await client.get_persistent_map_metadata(SERIAL, api_version=2)
+
+        url = mock_get.call_args.args[0]
+        assert f"/v2/app/{SERIAL}/persistent-map-metadata" in url
+        await client.close()
+
+    @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_v1_url_used_for_vis_nav(self, mock_get: AsyncMock) -> None:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        client = AsyncDysonClient(auth_token="tok")
+        await client.get_persistent_map_metadata(SERIAL, api_version=1)
+
+        url = mock_get.call_args.args[0]
+        assert f"/v1/app/{SERIAL}/persistent-map-metadata" in url
         await client.close()
 
 
@@ -624,7 +736,7 @@ class TestAsyncGetPersistentMap:
         mock_get.return_value = mock_response
 
         client = AsyncDysonClient(auth_token="tok")
-        pm = await client.get_persistent_map(SERIAL, MAP_ID)
+        pm = await client.get_persistent_map(SERIAL, MAP_ID, api_version=2)
 
         assert isinstance(pm, PersistentMap)
         assert pm.id == MAP_ID
@@ -635,7 +747,7 @@ class TestAsyncGetPersistentMap:
     async def test_raises_auth_error_when_not_authenticated(self) -> None:
         client = AsyncDysonClient()
         with pytest.raises(DysonAuthError):
-            await client.get_persistent_map(SERIAL, MAP_ID)
+            await client.get_persistent_map(SERIAL, MAP_ID, api_version=2)
         await client.close()
 
     @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
@@ -650,7 +762,37 @@ class TestAsyncGetPersistentMap:
 
         client = AsyncDysonClient(auth_token="tok")
         with pytest.raises(DysonAPIError, match="Expected object"):
-            await client.get_persistent_map(SERIAL, MAP_ID)
+            await client.get_persistent_map(SERIAL, MAP_ID, api_version=2)
+        await client.close()
+
+    @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_v2_url_includes_map_id(self, mock_get: AsyncMock) -> None:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = PERSISTENT_MAP_ITEM
+        mock_get.return_value = mock_response
+
+        client = AsyncDysonClient(auth_token="tok")
+        await client.get_persistent_map(SERIAL, MAP_ID, api_version=2)
+
+        url = mock_get.call_args.args[0]
+        assert f"/v2/app/{SERIAL}/persistent-maps/{MAP_ID}" in url
+        await client.close()
+
+    @patch("libdyson_rest.async_client.httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_v1_url_includes_map_id(self, mock_get: AsyncMock) -> None:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = PERSISTENT_MAP_ITEM
+        mock_get.return_value = mock_response
+
+        client = AsyncDysonClient(auth_token="tok")
+        await client.get_persistent_map(SERIAL, MAP_ID, api_version=1)
+
+        url = mock_get.call_args.args[0]
+        assert f"/v1/app/{SERIAL}/persistent-maps/{MAP_ID}" in url
         await client.close()
 
 

--- a/tests/unit/test_robot_models.py
+++ b/tests/unit/test_robot_models.py
@@ -766,6 +766,22 @@ class TestPersistentMapMeta:
         assert meta.zones == []
         assert meta.zones_definition_last_updated_date is None
 
+    def test_from_dict_is_current_map_true(self) -> None:
+        data = dict(MAP_META_RAW)
+        data["isCurrentMap"] = True
+        meta = PersistentMapMeta.from_dict(data)
+        assert meta.is_current_map is True
+
+    def test_from_dict_is_current_map_missing_defaults_false(self) -> None:
+        meta = PersistentMapMeta.from_dict(MAP_META_RAW)  # key absent
+        assert meta.is_current_map is False
+
+    def test_from_dict_is_current_map_explicit_false(self) -> None:
+        data = dict(MAP_META_RAW)
+        data["isCurrentMap"] = False
+        meta = PersistentMapMeta.from_dict(data)
+        assert meta.is_current_map is False
+
 
 # ---------------------------------------------------------------------------
 # PersistentMap

--- a/tests/unit/test_robot_models.py
+++ b/tests/unit/test_robot_models.py
@@ -782,6 +782,16 @@ class TestPersistentMapMeta:
         meta = PersistentMapMeta.from_dict(data)
         assert meta.is_current_map is False
 
+    def test_from_dict_last_visited(self) -> None:
+        data = dict(MAP_META_RAW)
+        data["lastVisited"] = "2026-07-11T16:39:57.525Z"
+        meta = PersistentMapMeta.from_dict(data)
+        assert meta.last_visited == "2026-07-11T16:39:57.525Z"
+
+    def test_from_dict_last_visited_missing_defaults_none(self) -> None:
+        meta = PersistentMapMeta.from_dict(MAP_META_RAW)  # key absent
+        assert meta.last_visited is None
+
 
 # ---------------------------------------------------------------------------
 # PersistentMap

--- a/tests/unit/test_robot_models.py
+++ b/tests/unit/test_robot_models.py
@@ -6,6 +6,7 @@ import zlib
 
 import pytest
 
+from libdyson_rest.exceptions import DysonMapError
 from libdyson_rest.models import (
     CleanedFootprint,
     CleanFault,
@@ -23,6 +24,7 @@ from libdyson_rest.models import (
     ZoneDustBreakdown,
     ZoneMeta,
     ZonePrediction,
+    find_current_map,
 )
 
 # ---------------------------------------------------------------------------
@@ -781,6 +783,82 @@ class TestPersistentMapMeta:
         data["isCurrentMap"] = False
         meta = PersistentMapMeta.from_dict(data)
         assert meta.is_current_map is False
+
+    def test_from_dict_last_visited_parsed(self) -> None:
+        data = dict(MAP_META_RAW)
+        data["lastVisited"] = "2026-07-11T14:32:00Z"
+        meta = PersistentMapMeta.from_dict(data)
+        assert meta.last_visited == "2026-07-11T14:32:00Z"
+
+    def test_from_dict_last_visited_missing_is_none(self) -> None:
+        meta = PersistentMapMeta.from_dict(MAP_META_RAW)  # key absent
+        assert meta.last_visited is None
+
+
+# ---------------------------------------------------------------------------
+# find_current_map
+# ---------------------------------------------------------------------------
+
+
+def _make_map(
+    id: str, is_current: bool = False, last_visited: str | None = None
+) -> PersistentMapMeta:
+    return PersistentMapMeta(
+        id=id,
+        name=None,
+        zones_definition_last_updated_date=None,
+        zones=[],
+        is_current_map=is_current,
+        last_visited=last_visited,
+    )
+
+
+class TestFindCurrentMap:
+    def test_v2_single_current(self) -> None:
+        maps = [_make_map("a", is_current=True)]
+        assert find_current_map(maps).id == "a"
+
+    def test_v2_picks_current_among_multiple(self) -> None:
+        maps = [
+            _make_map("a", is_current=False),
+            _make_map("b", is_current=True),
+            _make_map("c", is_current=False),
+        ]
+        assert find_current_map(maps).id == "b"
+
+    def test_v1_picks_most_recent_last_visited(self) -> None:
+        maps = [
+            _make_map("older", last_visited="2026-06-01T00:00:00Z"),
+            _make_map("newer", last_visited="2026-07-11T14:32:00Z"),
+        ]
+        assert find_current_map(maps).id == "newer"
+
+    def test_v1_ignores_map_without_last_visited(self) -> None:
+        maps = [
+            _make_map("visited", last_visited="2026-07-01T00:00:00Z"),
+            _make_map("unvisited"),
+        ]
+        assert find_current_map(maps).id == "visited"
+
+    def test_single_map_no_signal(self) -> None:
+        maps = [_make_map("solo")]
+        assert find_current_map(maps).id == "solo"
+
+    def test_raises_when_multiple_maps_no_signal(self) -> None:
+        maps = [_make_map("a"), _make_map("b")]
+        with pytest.raises(DysonMapError):
+            find_current_map(maps)
+
+    def test_raises_on_empty_list(self) -> None:
+        with pytest.raises(DysonMapError):
+            find_current_map([])
+
+    def test_v2_takes_priority_over_last_visited(self) -> None:
+        maps = [
+            _make_map("v1map", last_visited="2026-07-11T14:32:00Z"),
+            _make_map("v2map", is_current=True),
+        ]
+        assert find_current_map(maps).id == "v2map"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Breaking Change — libdyson-rest 0.16.0: `api_version` now required on map endpoints

Three methods now require an explicit `api_version: int` keyword argument.
There is no default — omitting it raises `TypeError`.

### Affected methods (sync and async)

| Method | Signature change |
|---|---|
| `get_clean_maps` | `get_clean_maps(serial, *, api_version, include_dust_map=True)` |
| `get_persistent_map_metadata` | `get_persistent_map_metadata(serial, *, api_version)` |
| `get_persistent_map` | `get_persistent_map(serial, map_id, *, api_version)` |

### Which value to pass

| Device | Serial prefix | Product type | `api_version` |
|---|---|---|---|
| Dyson 360 Vis Nav | `H8T` | `276B` | **1** |
| Dyson 360 Spot+Clean / Spot+Scrub | `VS6` / `RB05` | `804A` | **2** |

### Migration

```python
# Before (0.15.0 — broken for Vis Nav)
maps = client.get_clean_maps(serial)
meta = client.get_persistent_map_metadata(serial)
pm   = client.get_persistent_map(serial, map_id)

# After (0.16.0 — Vis Nav)
maps = client.get_clean_maps(serial, api_version=1)
meta = client.get_persistent_map_metadata(serial, api_version=1)
pm   = client.get_persistent_map(serial, map_id, api_version=1)

# After (0.16.0 — Spot+Clean / newer)
maps = client.get_clean_maps(serial, api_version=2)
meta = client.get_persistent_map_metadata(serial, api_version=2)
pm   = client.get_persistent_map(serial, map_id, api_version=2)
```

Note: get_clean_map_data is v2-only and is not affected by this change.
get_recommended_cleans, get_map_image, and set_zone_behaviour are also unchanged.

Fixes #203 
Closes #209 